### PR TITLE
Strict variables fixes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ end
 group :development do
   gem 'travis'
   gem 'travis-lint'
-  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.2.0'
+  gem 'puppet', ENV['PUPPET_VERSION'] || '~> 3.8'
   gem 'vagrant-wrapper'
   gem 'puppet-blacksmith'
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,7 +5,10 @@
 # === Parameters:
 #
 # nat_rfc1918 - if false, will not NAT traffic for RFC1918 space
-class masq ($nat_rfc1918 = true) {
+class masq (
+  $ensure      = present,
+  $nat_rfc1918 = true
+){
 
   unless ($::kernel == 'Linux') {
     fail("Sorry, ${::kernel} is unsupported")


### PR DESCRIPTION
- Explicitly set `ensure` in the `init.pp` 
  - this was brought up as a missing variable when running spec tests in one of our profile modules.
- Bump puppet version to `3.8` to fix spec tests